### PR TITLE
Clearer documentation/examples for ordering by meta keys

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -108,9 +108,13 @@ get_miniloops( array('order_by' => 'date' ) );`
 `[miniloop order=DESC]
 get_miniloops( array('order' => 'DESC' ) );`
 
-**Meta Key for ordering:** If order by = meta value, specify a key. Default: none
-`[miniloop meta_value=some_key]
-get_miniloops( array('meta_value' => 'some_key' ) );`
+**Ordering by the values of `some_key`** (works well if the values of `some_key` are strings/words):
+`[miniloop order_by=meta_value order_meta_key=some_key]
+get_miniloops( array('order_by' => 'meta_value', 'order_meta_key' => 'some_key' ) );`
+
+**Ordering by the numeric values of `some_key`** (works well if the values of `some_key` are numbers/integers):
+`[miniloop order_by=meta_value_num order_meta_key=some_key]
+get_miniloops( array('order_by' => 'meta_value_num', 'order_meta_key' => 'some_key' ) );`
 
 **Show posts in reverse order?** Perhaps you want the 3 most recent posts, but you want the oldest of those to be displayed first. If so, check this. Default: 0
 `[miniloop reverse_order=0]


### PR DESCRIPTION
I found it quite confusing when trying to sort a mini loop using the values of a postmeta custom field.

This PR updates the documentation to explain how to order by a custom field value, either using alphabetical sorting or numeric sorting.

See http://codex.wordpress.org/Class_Reference/WP_Query#Order_.26_Orderby_Parameters for more details.

You can see what this looks like by going to http://wordpress.org/plugins/about/validator/ and entering `https://raw.github.com/om4james/mini-loops/orderbymeta/readme.txt` in the readme URL field.