### PR TITLE
Changes URL if user is using SSL

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -750,7 +750,13 @@ function miniloop_image( $atts ) {
 
 	//if the above has resulted in an image
 	if ( ! empty( $src ) )
+	{
+		if(is_ssl()){
+			$src = str_replace( 'http://', 'https://', $src );
+		}
+	
 		$img = "<img src='$src' width='$width' height='$height' class='$class' alt='$alt' />";
+	}
 
 	//build the fallback
 	$fallback = ! empty( $fallback ) ? "<img src='$fallback' width='$width' height='$height' alt='$alt' class='$class' />" : '';


### PR DESCRIPTION
If you are browsing a site using SSL, the images are all hosted still without SSL, therefore causing a warning in the browser.

This is because, as of now, wordpress will only return the non-ssl version in baseurl that is used in the caching mechanism. This issue has been open for years - https://core.trac.wordpress.org/ticket/15928

I decided to do it this way rather than making the URL relative when accessing the cache, as I wasn't entirely sure what all may be reading or writing from the cache. If you would like me to move this when it is saving the URL, I can. 

We tried this in our setup, and it worked as expected. 
