### PR TITLE
PHP Notice Fixes

### DIFF
--- a/widget.php
+++ b/widget.php
@@ -43,7 +43,9 @@ class miniloops extends WP_Widget {
 		$instance['post_status'] = esc_attr( $new_instance['post_status'] );
 		$instance['order_by'] = esc_attr( $new_instance['order_by'] );
 		$instance['order'] = esc_attr( $new_instance['order'] );
-		$instance['order_meta_key'] = esc_attr( $new_instance['order_meta_key'] );
+		if ( isset( $new_instance['order_meta_key'] ) ) {
+			$instance['order_meta_key'] = esc_attr( $new_instance['order_meta_key'] );
+		}
 		$instance['reverse_order'] = (bool) $new_instance['reverse_order'] ? 1 : 0;
 		$instance['shuffle_order'] = (bool) $new_instance['shuffle_order'] ? 1 : 0;
 		$instance['ignore_sticky'] = (bool) $new_instance['ignore_sticky'] ? 1 : 0;
@@ -51,7 +53,9 @@ class miniloops extends WP_Widget {
 		$instance['exclude_sticky'] = (bool) $new_instance['exclude_sticky'] ? 1 : 0;
 		$instance['exclude_current'] = (bool) $new_instance['exclude_current'] ? 1 : 0;
 		$instance['current_category'] = (bool) $new_instance['current_category'] ? 1 : 0;
-		$instance['current_single_category'] = (bool) $new_instance['current_single_category'] ? 1 : 0;
+		if ( isset( $new_instance['current_single_category'] ) ) {
+			$instance['current_single_category'] = (bool) $new_instance['current_single_category'] ? 1 : 0;
+		}
 		$instance['current_author'] = (bool) $new_instance['current_author'] ? 1 : 0;
 		$instance['categories'] = esc_attr( $new_instance['categories'] );
 		$instance['tags'] = esc_attr( $new_instance['tags'] );
@@ -80,7 +84,7 @@ class miniloops extends WP_Widget {
 
 class miniminiloops extends miniloops {
 
-	function miniminiloops() {
+	public function __construct() {
 		$widget_ops = array('classname' => 'miniminiloops',
 							'description' => __( 'Query posts, display them.', 'mini-loops' )
 						);

--- a/widget.php
+++ b/widget.php
@@ -3,13 +3,13 @@ if ( ! defined( 'ABSPATH' ) ) die( '-1' );
 
 class miniloops extends WP_Widget {
 
-	function miniloops() {
+	public function __construct() {
 		$widget_ops = array('classname' => 'miniloops',
 							'description' => __( 'Query posts, display them.', 'mini-loops' )
 						);
 		$control_ops = array( 'width' => 700 );
 
-		parent::WP_Widget( 'miniloops', __( 'Mini Loops', 'mini-loops' ), $widget_ops, $control_ops );
+		parent::__construct( 'miniloops', __( 'Mini Loops', 'mini-loops' ), $widget_ops, $control_ops );
 	}
 
 	function widget( $args, $instance ) {
@@ -32,7 +32,9 @@ class miniloops extends WP_Widget {
 		$instance = $old_instance;
 		//get old variables
 		$instance['title'] = wp_filter_post_kses( $new_instance['title'] );
-		$instance['hide_title'] = (bool) $new_instance['hide_title'] ? 1 : 0;
+		if ( isset( $new_instance['hide_title'] ) ) {
+			$instance['hide_title'] = (bool) $new_instance['hide_title'] ? 1 : 0;
+		}
 		$instance['title_url'] = esc_url( $new_instance['title_url'] );
 		$instance['number_posts'] = (int) $new_instance['number_posts'];
 		$instance['post_offset'] = (int) $new_instance['post_offset'];
@@ -84,7 +86,7 @@ class miniminiloops extends miniloops {
 						);
 		$control_ops = array(  );
 
-		parent::WP_Widget( 'miniminiloops', __( 'Mini Mini Loops', 'mini-loops' ), $widget_ops, $control_ops );
+		parent::__construct( 'miniminiloops', __( 'Mini Mini Loops', 'mini-loops' ), $widget_ops, $control_ops );
 	}
 
 	function form( $instance ) {


### PR DESCRIPTION
Hi @trepmal, 

This PR fixes a PHP notices that occurs in WordPress 4.3 and newer due to WP_Widget's constructor changing. See https://make.wordpress.org/core/2015/07/02/deprecating-php4-style-constructors-in-wordpress-4-3/.

It also fixes 3 PHP notices that occur when saving a mini loops widget.

It would be _greatly_ appreciated if you could merge this PR, and release a new version of the plugin.

We are using the Mini Loops plugin on 50+ client sites, and these deprecated warnings are polluting our error logs.

The changes in this PR should be quite straightforward.

Please let me know!

James
